### PR TITLE
Add libsamplerate resampling and silence trimming

### DIFF
--- a/src/extract_mels/CMakeLists.txt
+++ b/src/extract_mels/CMakeLists.txt
@@ -7,12 +7,13 @@ find_package(YAML-CPP REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(SNDFILE REQUIRED sndfile)
+pkg_check_modules(SAMPLERATE REQUIRED samplerate)
 
 add_executable(extract_mels extract_mels.cpp)
 
-target_include_directories(extract_mels PRIVATE ${SNDFILE_INCLUDE_DIRS})
+target_include_directories(extract_mels PRIVATE ${SNDFILE_INCLUDE_DIRS} ${SAMPLERATE_INCLUDE_DIRS})
 
-target_link_libraries(extract_mels PRIVATE yaml-cpp ${SNDFILE_LIBRARIES})
+target_link_libraries(extract_mels PRIVATE yaml-cpp ${SNDFILE_LIBRARIES} ${SAMPLERATE_LIBRARIES})
 
 # Optional: nlohmann/json and cnpy as header-only
 find_package(nlohmann_json REQUIRED)


### PR DESCRIPTION
## Summary
- resample audio in C++ implementation using libsamplerate when needed
- add trimming based on `top_db`
- link samplerate in CMake

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_68541330c518832bb73f08caba1f540d