### PR TITLE
Improve parse_audio error reporting

### DIFF
--- a/src/extract_mels/extract_mels.cpp
+++ b/src/extract_mels/extract_mels.cpp
@@ -55,7 +55,13 @@ std::vector<float> parse_audio(const std::string &path, int target_sr) {
     SF_INFO sfinfo;
     SNDFILE *snd = sf_open(path.c_str(), SFM_READ, &sfinfo);
     if (!snd) {
-        throw std::runtime_error("Unable to open audio: " + path);
+        bool file_exists = fs::exists(path);
+        std::string msg = "Unable to open audio: " + path + " (" +
+                          std::string(sf_strerror(nullptr)) + ")";
+        if (!file_exists) {
+            msg += " [file not found]";
+        }
+        throw std::runtime_error(msg);
     }
 
     std::vector<float> data(sfinfo.frames * sfinfo.channels);


### PR DESCRIPTION
## Summary
- refine error handling when opening audio files in extract_mels

## Testing
- `cmake ../src/extract_mels` *(fails: FindYAML-CPP.cmake not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_6854212ee988832bae2c5356d06e7190