### PR TITLE
Switch audio decoding to FFmpeg

### DIFF
--- a/src/extract_mels/CMakeLists.txt
+++ b/src/extract_mels/CMakeLists.txt
@@ -6,8 +6,10 @@ set(CMAKE_CXX_STANDARD 17)
 # Dipendenze base
 find_package(YAML-CPP REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(SNDFILE REQUIRED sndfile)
-pkg_check_modules(SAMPLERATE REQUIRED samplerate)
+pkg_check_modules(AVFORMAT REQUIRED libavformat)
+pkg_check_modules(AVCODEC REQUIRED libavcodec)
+pkg_check_modules(AVUTIL REQUIRED libavutil)
+pkg_check_modules(SWRESAMPLE REQUIRED libswresample)
 find_package(nlohmann_json REQUIRED)
 find_package(ZLIB REQUIRED)
 
@@ -16,16 +18,20 @@ add_executable(extract_mels extract_mels.cpp)
 
 # Include directories
 target_include_directories(extract_mels PRIVATE
-    ${SNDFILE_INCLUDE_DIRS}
-    ${SAMPLERATE_INCLUDE_DIRS}
+    ${AVFORMAT_INCLUDE_DIRS}
+    ${AVCODEC_INCLUDE_DIRS}
+    ${AVUTIL_INCLUDE_DIRS}
+    ${SWRESAMPLE_INCLUDE_DIRS}
     /usr/local/include  # dove si trova cnpy.h
 )
 
 # Link libraries
 target_link_libraries(extract_mels PRIVATE
     yaml-cpp
-    ${SNDFILE_LIBRARIES}
-    ${SAMPLERATE_LIBRARIES}
+    ${AVFORMAT_LIBRARIES}
+    ${AVCODEC_LIBRARIES}
+    ${AVUTIL_LIBRARIES}
+    ${SWRESAMPLE_LIBRARIES}
     nlohmann_json::nlohmann_json
     /usr/local/lib/libcnpy.a  # oppure .so se preferisci dinamico
     ZLIB::ZLIB


### PR DESCRIPTION
## Summary
- switch `extract_mels.cpp` to use FFmpeg for reading and resampling audio
- update CMake to link with FFmpeg libraries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_685421fbbb40832b9e53ed8bd87e9cd4