### PR TITLE
Add causal mode for Conformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ python scripts/train.py \
   --dev_mel_dir output/mel_segments/dev/ \
   --dev_target_dir output/frame_targets/dev/ \
   --output_dir output/models/ \
-  --batch_size 32 --epochs 50 --patience 5
+  --batch_size 32 --epochs 50 --patience 5 \
+  --causal
 ```
+
+Usa l'opzione `--causal` per abilitare una configurazione compatibile con lo streaming.
 
 Il file `training_log.csv` verrà generato nella directory di output con le metriche di ogni epoca.
 
@@ -221,3 +224,4 @@ python scripts/stream_inference.py \
   --model output/models/best_model.keras \
   --decode
 ```
+Il modello deve essere stato addestrato con l'opzione `--causal` per garantire uno streaming corretto.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument("--epochs", type=int, default=50)
     parser.add_argument("--patience", type=int, default=5)
     parser.add_argument("--reset-output", action="store_true", help="Rimuove il contenuto della cartella di output all'avvio")
+    parser.add_argument("--causal", action="store_true", help="Usa il modello in modalit\u00e0 causale per lo streaming")
     args = parser.parse_args()
 
     if args.reset_output and os.path.exists(args.output_dir):
@@ -46,7 +47,8 @@ def main():
     model = build_model(
         n_mels=config["n_mels"],
         n_classes=config["num_classes"],
-        dropout=config.get("dropout", 0.3)
+        dropout=config.get("dropout", 0.3),
+        causal=args.causal
     )
 
     model.compile(


### PR DESCRIPTION
## Summary
- allow enabling causal attention/convolutions in Conformer model
- support `--causal` flag in training script
- document streaming-friendly training option in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_685646d7386c832bb4a98cb8da6972e1